### PR TITLE
Integrate a TWRP device tree generation tool in dumpyara. Fix a bug in sanitize, and update tools repos whenever changed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ extract-ikconfig
 Firmware_extractor/
 input/
 mkbootimg_tools/
+TWRP-device-tree-generator/
 vmlinux-to-elf/
 working/

--- a/dumpyara.sh
+++ b/dumpyara.sh
@@ -20,7 +20,7 @@ if echo "$1" | grep -e '^\(https\?\|ftp\)://.*$' > /dev/null; then
     URL=$1
     cd "$PROJECT_DIR"/input || exit
     { type -p aria2c > /dev/null 2>&1 && printf "Downloading File...\n" && aria2c -x16 -j"$(nproc)" "${URL}"; } || { printf "Downloading File...\n" && wget -q --show-progress --progress=bar:force "${URL}" || exit 1; }
-    detox "${URL}"
+    detox "${URL##*/}"
 else
     URL=$(printf "%s\n" "$1")
     [[ -e "$URL" ]] || { echo "Invalid Input" && exit 1; }

--- a/dumpyara.sh
+++ b/dumpyara.sh
@@ -180,6 +180,7 @@ fi
 if [[ -f "$PROJECT_DIR"/working/"${UNZIP_DIR}"/"${twrpimg}" ]]; then
     python3 -m twrpdtgen "$PROJECT_DIR"/working/"${UNZIP_DIR}"/"${twrpimg}"
     if [[ "$?" = 0 ]]; then
+        rm -rf "$PROJECT_DIR"/TWRP-device-tree-generator/working/*/*/.git
         mkdir -p "$PROJECT_DIR"/working/"${UNZIP_DIR}"/twrp-device-tree
         mv "$PROJECT_DIR"/TWRP-device-tree-generator/working/* "$PROJECT_DIR"/working/"${UNZIP_DIR}"/twrp-device-tree
         [[ ! -e "${PROJECT_DIR}"/working/"${UNZIP_DIR}"/twrp-device-tree/README.md ]] && curl https://raw.githubusercontent.com/wiki/SebaUbuntu/TWRP-device-tree-generator/4.-Build-TWRP-from-source.md > "$PROJECT_DIR"/working/"${UNZIP_DIR}"/twrp-device-tree/README.md

--- a/dumpyara.sh
+++ b/dumpyara.sh
@@ -117,11 +117,6 @@ if [ -e "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor/build.prop ]; then
 fi
 sort -u -o "$PROJECT_DIR"/working/"${UNZIP_DIR}"/board-info.txt "$PROJECT_DIR"/working/"${UNZIP_DIR}"/board-info.txt
 
-# copy file names
-chown "$(whoami)" ./* -R
-chmod -R u+rwX ./* #ensure final permissions
-find "$PROJECT_DIR"/working/"${UNZIP_DIR}" -type f -printf '%P\n' | sort | grep -v ".git/" > "$PROJECT_DIR"/working/"${UNZIP_DIR}"/all_files.txt
-
 # set variables
 ls system/build*.prop 2> /dev/null || ls system/system/build*.prop 2> /dev/null || { echo "No system build*.prop found, pushing cancelled!" && exit; }
 flavor=$(grep -oP "(?<=^ro.build.flavor=).*" -hs {system,system/system,vendor}/build*.prop)
@@ -191,6 +186,11 @@ if [[ -f "$PROJECT_DIR"/working/"${UNZIP_DIR}"/"${twrpimg}" ]]; then
     fi
 fi
 cd "$PROJECT_DIR"/working/"${UNZIP_DIR}"
+
+# copy file names
+chown "$(whoami)" ./* -R
+chmod -R u+rwX ./* #ensure final permissions
+find "$PROJECT_DIR"/working/"${UNZIP_DIR}" -type f -printf '%P\n' | sort | grep -v ".git/" > "$PROJECT_DIR"/working/"${UNZIP_DIR}"/all_files.txt
 
 if [[ -n $GIT_OAUTH_TOKEN ]]; then
     curl --silent --fail "https://raw.githubusercontent.com/$ORG/$repo/$branch/all_files.txt" 2> /dev/null && echo "Firmware already dumped!" && exit 1

--- a/dumpyara.sh
+++ b/dumpyara.sh
@@ -46,13 +46,19 @@ if [[ -d "$PROJECT_DIR/Firmware_extractor" ]]; then
 else
     git clone -q --recurse-submodules https://github.com/AndroidDumps/Firmware_extractor "$PROJECT_DIR"/Firmware_extractor
 fi
-if [[ ! -d "$PROJECT_DIR/extract-dtb" ]]; then
+if [[ -d "$PROJECT_DIR/extract-dtb" ]]; then
+    git -C "$PROJECT_DIR"/extract-dtb pull --recurse-submodules
+else
     git clone -q https://github.com/PabloCastellano/extract-dtb "$PROJECT_DIR"/extract-dtb
 fi
-if [[ ! -d "$PROJECT_DIR/mkbootimg_tools" ]]; then
+if [[ -d "$PROJECT_DIR/mkbootimg_tools" ]]; then
+    git -C "$PROJECT_DIR"/mkbootimg_tools pull --recurse-submodules
+else
     git clone -q https://github.com/carlitros900/mkbootimg_tools "$PROJECT_DIR/mkbootimg_tools"
 fi
-if [[ ! -d "$PROJECT_DIR/vmlinux-to-elf" ]]; then
+if [[ -d "$PROJECT_DIR/vmlinux-to-elf" ]]; then
+    git -C "$PROJECT_DIR"/vmlinux-to-elf pull --recurse-submodules
+else
     git clone -q https://github.com/marin-m/vmlinux-to-elf "$PROJECT_DIR/vmlinux-to-elf"
 fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
-    sudo apt install unace unrar zip unzip p7zip-full p7zip-rar sharutils rar uudeview mpack arj cabextract file-roller device-tree-compiler liblzma-dev python3-pip brotli liblz4-tool axel gawk aria2 detox
+    sudo apt install unace unrar zip unzip p7zip-full p7zip-rar sharutils rar uudeview mpack arj cabextract file-roller device-tree-compiler liblzma-dev python3-pip brotli liblz4-tool axel gawk aria2 detox cpio
     pip3 install backports.lzma protobuf pycrypto docopt
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     brew install protobuf xz brotli lz4 aria2


### PR DESCRIPTION
Integrate a TWRP device tree generation tool in dumpyara
This integration requires a PR in [https://github.com/AndroidDumps/Firmware_extractor/pull/4](url) in order to have recovery.img extracted.
Also, fix a bug in sanitize, and update tools repos whenever changed