### PR TITLE
Disable git creation of twrpdtgen

### DIFF
--- a/dumpyara.sh
+++ b/dumpyara.sh
@@ -172,9 +172,8 @@ else
 fi
 if [[ -f "${twrpimg}" ]]; then
     twrpdt="$PROJECT_DIR"/working/"${UNZIP_DIR}"/twrp-device-tree
-    python3 -m twrpdtgen "$twrpimg" --output "$twrpdt" -v
+    python3 -m twrpdtgen "$twrpimg" --output "$twrpdt" --no-git -v
     if [[ "$?" = 0 ]]; then
-        rm -rf "$twrpdt"/*/*/.git
         [[ ! -e "$twrpdt"/README.md ]] && curl https://raw.githubusercontent.com/wiki/SebaUbuntu/TWRP-device-tree-generator/4.-Build-TWRP-from-source.md > "$twrpdt"/README.md
     fi
 fi


### PR DESCRIPTION
Use --no-git option to disable the .git creation in twrpdtgen. Then, is not necessary remove it.