### PR TITLE
Handle e.g. EROFS images

### DIFF
--- a/dumpyara.sh
+++ b/dumpyara.sh
@@ -100,7 +100,26 @@ for p in $PARTITIONS; do
         mkdir "$p" 2> /dev/null || rm -rf "${p:?}"/*
         echo "Extracting $p partition"
         7z x "$p".img -y -o"$p"/ > /dev/null 2>&1
-        rm "$p".img > /dev/null 2>&1
+        if [ $? -eq 0 ]; then
+            rm "$p".img > /dev/null 2>&1
+        else 
+        #handling e.g. erofs images, which can't be handled by 7z
+            if [ -f $p.img ] && [ $p != "modem" ]; then
+                echo "Couldn't extract $p partition by 7z binary. Script will try to mount it instead (sudo password might be needed once)"
+                rm -rf "${p}"/* # to avoid "cannot overwrite non-directory 'system/system' with directory 'system_/system'" error
+                mkdir "${p}_/" || rm -rf "${p:?}"/*
+                sudo mount -t auto -o loop "$p".img "${p}_/"
+                if [ $? -eq 0 ]; then
+                    sudo cp -rf "${p}_/"* "${p}"
+                    sudo umount "${p}_/"
+                    sudo rm -rf "${p}_/"
+                    rm -fv "$p".img > /dev/null 2>&1
+                    sudo chown $(whoami) "${p}/" -R
+                else
+                    echo "Couldn't extract $p partition. It might use an unsupported filesystem. For EROFS: make sure you're using Linux 5.4+ kernel"
+                fi
+            fi
+        fi
     fi
 done
 


### PR DESCRIPTION
7z can't handle EROFS so adding sudo mount (supported on Linux 5.4+).
Tested with Xiaomi Civi ROM V12.5.3.0.RKVCNXM.