### PR TITLE
Fix missing packages and Illegal byte sequence in macOS environment

### DIFF
--- a/dumpyara.sh
+++ b/dumpyara.sh
@@ -2,6 +2,11 @@
 
 [[ $# = 0 ]] && echo "No Input" && exit 1
 
+OS=`uname`
+if [ "$OS" = 'Darwin' ]; then
+    export LC_CTYPE=C
+fi
+
 PROJECT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 # Create input & working directory if it does not exist
 mkdir -p "$PROJECT_DIR"/input "$PROJECT_DIR"/working

--- a/setup.sh
+++ b/setup.sh
@@ -8,7 +8,7 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
     fi
     PIP=pip3
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-    brew install protobuf xz brotli lz4 aria2
+    brew install protobuf xz brotli lz4 aria2 detox coreutils p7zip gawk
     PIP=pip
 fi
 


### PR DESCRIPTION
Tested on macOS Version: 11.6.1 (Big Sur)