### PR TITLE
Add EROFS support

### DIFF
--- a/dumpyara.sh
+++ b/dumpyara.sh
@@ -105,7 +105,21 @@ for p in $PARTITIONS; do
         mkdir "$p" 2> /dev/null || rm -rf "${p:?}"/*
         echo "Extracting $p partition"
         7z x "$p".img -y -o"$p"/ > /dev/null 2>&1
-        rm "$p".img > /dev/null 2>&1
+        if [ $? -eq 0 ]; then
+            rm "$p".img > /dev/null 2>&1
+        else
+        #handling erofs images, which can't be handled by 7z
+            if [ -f $p.img ] && [ $p != "modem" ]; then
+                echo "Couldn't extract $p partition by 7z. Using fsck.erofs."
+                rm -rf "${p}"/*
+                "$PROJECT_DIR"/Firmware_extractor/tools/Linux/bin/fsck.erofs --extract="$p" "$p".img
+                if [ $? -eq 0 ]; then
+                    rm -fv "$p".img > /dev/null 2>&1
+                else
+                    echo "Couldn't extract $p partition. It might use an unsupported filesystem. For EROFS: make sure you're using Linux 5.4+ kernel"
+                fi
+            fi
+        fi
     fi
 done
 

--- a/setup.sh
+++ b/setup.sh
@@ -2,9 +2,9 @@
 
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
     if [[ "$(command -v apt)" != "" ]]; then
-        sudo apt install unace unrar zip unzip p7zip-full p7zip-rar sharutils rar uudeview mpack arj cabextract device-tree-compiler liblzma-dev python3-pip brotli liblz4-tool axel gawk aria2 detox cpio rename
+        sudo apt install unace unrar zip unzip p7zip-full p7zip-rar sharutils rar uudeview mpack arj cabextract device-tree-compiler liblzma-dev python3-pip brotli liblz4-tool axel gawk aria2 detox cpio rename liblz4-dev
     elif [[ "$(command -v pacman)" != "" ]]; then
-        sudo pacman -Sy --noconfirm unace unrar zip unzip p7zip sharutils uudeview arj cabextract file-roller dtc python-pip brotli axel gawk aria2 detox cpio
+        sudo pacman -Sy --noconfirm unace unrar zip unzip p7zip sharutils uudeview arj cabextract file-roller dtc python-pip brotli axel gawk aria2 detox cpio liblz4-devel
     fi
     PIP=pip3
 elif [[ "$OSTYPE" == "darwin"* ]]; then


### PR DESCRIPTION
There's finally the working method, which doesn't require sudo privileges. If 7z fails to extract partition, script will try to use fsck.erofs added to Firmware extractor ([pull request there](https://github.com/AndroidDumps/Firmware_extractor/pull/16)).