### PR TITLE
Move liblz4-devel to lz4 for Arch

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,7 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
     if [[ "$(command -v apt)" != "" ]]; then
         sudo apt install unace unrar zip unzip p7zip-full p7zip-rar sharutils rar uudeview mpack arj cabextract device-tree-compiler liblzma-dev python3-pip brotli liblz4-tool axel gawk aria2 detox cpio rename liblz4-dev
     elif [[ "$(command -v pacman)" != "" ]]; then
-        sudo pacman -Sy --noconfirm unace unrar zip unzip p7zip sharutils uudeview arj cabextract file-roller dtc python-pip brotli axel gawk aria2 detox cpio liblz4-devel
+        sudo pacman -Sy --noconfirm unace unrar zip unzip p7zip sharutils uudeview arj cabextract file-roller dtc python-pip brotli axel gawk aria2 detox cpio lz4
     fi
     PIP=pip3
 elif [[ "$OSTYPE" == "darwin"* ]]; then


### PR DESCRIPTION
error: target not found: liblz4-devel

After checking the official package repos, lz4 provides the required files.

Ref: https://archlinux.org/packages/core/x86_64/lz4/