### PR TITLE
"FIX" protobuf error

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -14,4 +14,4 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
     PIP=pip
 fi
 
-sudo "$PIP" install backports.lzma extract-dtb protobuf pycrypto docopt zstandard twrpdtgen
+sudo "$PIP" install backports.lzma extract-dtb protobuf==3.20.* pycrypto docopt zstandard twrpdtgen


### PR DESCRIPTION
Traceback (most recent call last):
  File "/home/adhitya/yaap/dump/Firmware_extractor/tools/extract_android_ota_payload/extract_android_ota_payload.py", line 13, in <module>
    import update_metadata_pb2
  File "/home/adhitya/yaap/dump/Firmware_extractor/tools/extract_android_ota_payload/update_metadata_pb2.py", line 34, in <module>
    _descriptor.EnumValueDescriptor(
  File "/usr/lib/python3.10/site-packages/google/protobuf/descriptor.py", line 755, in __new__
    _message.Message._CheckCalledFromGeneratedFile()
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).

https://stackoverflow.com/questions/72441758/typeerror-descriptors-cannot-not-be-created-directly/72493690#72493690

https://github.com/protocolbuffers/protobuf/issues/10051