### PR TITLE
setup.sh: Switch from PyCrypto to PyCryptodome

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -27,4 +27,4 @@ fi
 # Create virtual environment and install packages
 python3 -m venv .venv
 source .venv/bin/activate
-"$PIP" install aospdtgen backports.lzma extract-dtb protobuf pycrypto docopt zstandard
+"$PIP" install aospdtgen backports.lzma extract-dtb protobuf pycryptodome docopt zstandard


### PR DESCRIPTION
* PyCrypto is deprecated And with python 3.11.x there's no longer installable

Ref:
https://www.pycrypto.org
https://www.pycryptodome.org