### PR TITLE
feat: Bring extraction of `vendor_boot.img`, `vendor_kernel_boot.img` and more

### DIFF
--- a/dumpyara.sh
+++ b/dumpyara.sh
@@ -99,7 +99,7 @@ if [[ -f "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot.img ]]; then
     # Extract 'dtb' and decompile then
     extract-dtb "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot.img -o "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot/dtb > /dev/null
     rm -rf "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot/dtb/00_kernel
-    if [ $(ls "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot/dtb) ]; then
+    if [ "$(find "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot/dtb -name "*.dtb)" ]; then
         for dtb in $(find "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot/dtb); do
             dtc -q -I dtb -O dts "${dtb}" >> "${PROJECT_DIR}/working/${UNZIP_DIR}/boot/dts/$(basename "${dtb}" | sed 's/\.dtb/.dts/')"
         done
@@ -134,7 +134,7 @@ if [[ -f "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_boot.img ]]; then
 
     # Extract 'dtb' and decompile then
     extract-dtb "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_boot.img -o "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_boot/dtb > /dev/null
-    if [ $(ls "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_boot/dtb) ]; then
+    if [ "$(find "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_boot/dtb -name "*.dtb")" ]; then
         for dtb in $(find "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_boot/dtb); do
             dtc -q -I dtb -O dts "${dtb}" >> "${PROJECT_DIR}/working/${UNZIP_DIR}/vendor_boot/dts/$(basename "${dtb}" | sed 's/\.dtb/.dts/')"
         done
@@ -159,7 +159,7 @@ if [[ -f "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_kernel_boot.img ]]; then
     # Extract 'dtb' and decompile then
     extract-dtb "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_kernel_boot.img -o "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_kernel_boot/dtb > /dev/null
     rm -rf "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_kernel_boot/dtb/00_kernel
-    if [ $(ls "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_kernel_boot/dtb) ]; then
+    if [ "$(find "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_kernel_boot/dtb -name *.dtb)" ]; then
         for dtb in $(find "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_kernel_boot/dtb); do
             dtc -q -I dtb -O dts "${dtb}" >> "${PROJECT_DIR}/working/${UNZIP_DIR}/vendor_kernel_boot/dts/$(basename "${dtb}" | sed 's/\.dtb/.dts/')"
         done

--- a/dumpyara.sh
+++ b/dumpyara.sh
@@ -81,15 +81,22 @@ fi
 # extract rom via Firmware_extractor
 [[ ! -d "$1" ]] && bash "$PROJECT_DIR"/Firmware_extractor/extractor.sh "$PROJECT_DIR"/input/"${FILE}" "$PROJECT_DIR"/working/"${UNZIP_DIR}"
 
-# Extract boot.img
+# Extract 'boot.img'
 if [[ -f "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot.img ]]; then
-    extract-dtb "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot.img -o "$PROJECT_DIR"/working/"${UNZIP_DIR}"/bootimg > /dev/null # Extract boot
-    bash "$PROJECT_DIR"/mkbootimg_tools/mkboot "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot.img "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot > /dev/null 2>&1
+    # Create necessary directories
+    mkdir -p "${PROJECT_DIR}/working/${UNZIP_DIR}/boot/dtb"
+    mkdir -p "${PROJECT_DIR}/working/${UNZIP_DIR}/boot/dts"
+
+    # Extract 'boot.img' content, alongside device-tree blobs
+    "${PROJECT_DIR}/Firmware_extractor/tools/Linux/bin/unpackbootimg" -i "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot.img -o "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot > /dev/null 2>&1
+    extract-dtb "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot.img -o "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot/dtb > /dev/null
     echo 'boot extracted'
-    # extract-ikconfig
+
+    # Run 'extract-ikconfig'
     [[ ! -e "${PROJECT_DIR}"/extract-ikconfig ]] && curl https://raw.githubusercontent.com/torvalds/linux/master/scripts/extract-ikconfig > ${PROJECT_DIR}/extract-ikconfig
     bash "${PROJECT_DIR}"/extract-ikconfig "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot.img > "$PROJECT_DIR"/working/"${UNZIP_DIR}"/ikconfig
-    # vmlinux-to-elf
+
+    # Run 'vmlinux-to-elf'
     mkdir -p "$PROJECT_DIR"/working/"${UNZIP_DIR}"/bootRE
     python3 "${PROJECT_DIR}"/vmlinux-to-elf/vmlinux_to_elf/kallsyms_finder.py "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot.img > "$PROJECT_DIR"/working/"${UNZIP_DIR}"/bootRE/boot_kallsyms.txt 2>&1
     echo 'boot_kallsyms.txt generated'

--- a/dumpyara.sh
+++ b/dumpyara.sh
@@ -145,6 +145,30 @@ if [[ -f "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_boot.img ]]; then
     fi
 fi
 
+# Extract 'vendor_kernel_boot'
+if [[ -f "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_kernel_boot.img ]]; then
+    # Create necessary directories
+    mkdir -p "${PROJECT_DIR}/working/${UNZIP_DIR}/vendor_kernel_boot/dtb"
+    mkdir -p "${PROJECT_DIR}/working/${UNZIP_DIR}/vendor_kernel_boot/dts"
+
+    # Extract 'vendor_boot.img' content(s)
+    "${UNPACKBOOTIMG}" -i "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_kernel_boot.img -o "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_kernel_boot > /dev/null 2>&1
+    echo 'vendor_kernel_boot extracted'
+
+    # Extract 'dtb' and decompile then
+    extract-dtb "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_kernel_boot.img -o "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_kernel_boot/dtb > /dev/null
+    if [ $(ls "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_kernel_boot/dtb) ]; then
+        for dtb in $(find "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_kernel_boot/dtb); do
+            dtc -q -I dtb -O dts "${dtb}" >> "${PROJECT_DIR}/working/${UNZIP_DIR}/vendor_kernel_boot/dts/$(basename "${dtb}" | sed 's/\.dtb/.dts/')"
+        done
+        echo 'vendor_kernel_boot (dtb, dts) extracted'
+    else
+        # Extraction failed, device-tree resources are probably somewhere else.
+        rm -rf "${PROJECT_DIR}/working/${UNZIP_DIR}/vendor_kernel_boot/dtb"
+        rm -rf "${PROJECT_DIR}/working/${UNZIP_DIR}/vendor_kernel_boot/dts"
+    fi
+fi
+
 if [[ -f "$PROJECT_DIR"/working/"${UNZIP_DIR}"/dtbo.img ]]; then
     # Create necessary directories
     mkdir -p "$PROJECT_DIR"/working/"${UNZIP_DIR}"/dtbo/dts

--- a/dumpyara.sh
+++ b/dumpyara.sh
@@ -121,6 +121,30 @@ if [[ -f "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot.img ]]; then
     echo 'boot.elf generated'
 fi
 
+# Extract 'vendor_boot'
+if [[ -f "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_boot.img ]]; then
+    # Create necessary directories
+    mkdir -p "${PROJECT_DIR}/working/${UNZIP_DIR}/vendor_boot/dtb"
+    mkdir -p "${PROJECT_DIR}/working/${UNZIP_DIR}/vendor_boot/dts"
+
+    # Extract 'vendor_boot.img' content(s)
+    "${UNPACKBOOTIMG}" -i "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_boot.img -o "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_boot > /dev/null 2>&1
+    echo 'vendor_boot extracted'
+
+    # Extract 'dtb' and decompile then
+    extract-dtb "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_boot.img -o "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_boot/dtb > /dev/null
+    if [ $(ls "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_boot/dtb) ]; then
+        for dtb in $(find "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_boot/dtb); do
+            dtc -q -I dtb -O dts "${dtb}" >> "${PROJECT_DIR}/working/${UNZIP_DIR}/vendor_boot/dts/$(basename "${dtb}" | sed 's/\.dtb/.dts/')"
+        done
+        echo 'vendor_boot (dtb, dts) extracted'
+    else
+        # Extraction failed, device-tree resources are probably somewhere else.
+        rm -rf "${PROJECT_DIR}/working/${UNZIP_DIR}/vendor_boot/dtb"
+        rm -rf "${PROJECT_DIR}/working/${UNZIP_DIR}/vendor_boot/dts"
+    fi
+fi
+
 if [[ -f "$PROJECT_DIR"/working/"${UNZIP_DIR}"/dtbo.img ]]; then
     # Create necessary directories
     mkdir -p "$PROJECT_DIR"/working/"${UNZIP_DIR}"/dtbo/dts

--- a/dumpyara.sh
+++ b/dumpyara.sh
@@ -72,11 +72,6 @@ if [[ -d "$PROJECT_DIR/Firmware_extractor" ]]; then
 else
     git clone -q --recurse-submodules https://github.com/AndroidDumps/Firmware_extractor "$PROJECT_DIR"/Firmware_extractor
 fi
-if [[ -d "$PROJECT_DIR/mkbootimg_tools" ]]; then
-    git -C "$PROJECT_DIR"/mkbootimg_tools pull --recurse-submodules
-else
-    git clone -q https://github.com/carlitros900/mkbootimg_tools "$PROJECT_DIR/mkbootimg_tools"
-fi
 if [[ -d "$PROJECT_DIR/vmlinux-to-elf" ]]; then
     git -C "$PROJECT_DIR"/vmlinux-to-elf pull --recurse-submodules
 else

--- a/dumpyara.sh
+++ b/dumpyara.sh
@@ -81,6 +81,11 @@ fi
 # extract rom via Firmware_extractor
 [[ ! -d "$1" ]] && bash "$PROJECT_DIR"/Firmware_extractor/extractor.sh "$PROJECT_DIR"/input/"${FILE}" "$PROJECT_DIR"/working/"${UNZIP_DIR}"
 
+# Set path for tools
+UNPACKBOOTIMG="${PROJECT_DIR}"/Firmware_extractor/tools/Linux/bin/unpackbootimg
+KALLSYMS_FINDER="${PROJECT_DIR}"/vmlinux-to-elf/vmlinux_to_elf/kallsyms_finder.py
+VMLINUX_TO_ELF="${PROJECT_DIR}"/vmlinux-to-elf/vmlinux_to_elf/main.py
+
 # Extract 'boot.img'
 if [[ -f "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot.img ]]; then
     # Create necessary directories
@@ -88,7 +93,7 @@ if [[ -f "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot.img ]]; then
     mkdir -p "${PROJECT_DIR}/working/${UNZIP_DIR}/boot/dts"
 
     # Extract 'boot.img' content, alongside device-tree blobs
-    "${PROJECT_DIR}/Firmware_extractor/tools/Linux/bin/unpackbootimg" -i "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot.img -o "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot > /dev/null 2>&1
+    "${UNPACKBOOTIMG}" -i "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot.img -o "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot > /dev/null 2>&1
     extract-dtb "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot.img -o "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot/dtb > /dev/null
     echo 'boot extracted'
 
@@ -98,9 +103,9 @@ if [[ -f "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot.img ]]; then
 
     # Run 'vmlinux-to-elf'
     mkdir -p "$PROJECT_DIR"/working/"${UNZIP_DIR}"/bootRE
-    python3 "${PROJECT_DIR}"/vmlinux-to-elf/vmlinux_to_elf/kallsyms_finder.py "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot.img > "$PROJECT_DIR"/working/"${UNZIP_DIR}"/bootRE/boot_kallsyms.txt 2>&1
+    python3 ${KALLSYMS_FINDER} "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot.img > "$PROJECT_DIR"/working/"${UNZIP_DIR}"/bootRE/boot_kallsyms.txt 2>&1
     echo 'boot_kallsyms.txt generated'
-    python3 "${PROJECT_DIR}"/vmlinux-to-elf/vmlinux_to_elf/main.py "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot.img "$PROJECT_DIR"/working/"${UNZIP_DIR}"/bootRE/boot.elf > /dev/null 2>&1
+    python3 ${VMLINUX_TO_ELF} "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot.img "$PROJECT_DIR"/working/"${UNZIP_DIR}"/bootRE/boot.elf > /dev/null 2>&1
     echo 'boot.elf generated'
 fi
 

--- a/dumpyara.sh
+++ b/dumpyara.sh
@@ -98,6 +98,7 @@ if [[ -f "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot.img ]]; then
 
     # Extract 'dtb' and decompile then
     extract-dtb "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot.img -o "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot/dtb > /dev/null
+    rm -rf "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot/dtb/00_kernel
     if [ $(ls "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot/dtb) ]; then
         for dtb in $(find "$PROJECT_DIR"/working/"${UNZIP_DIR}"/boot/dtb); do
             dtc -q -I dtb -O dts "${dtb}" >> "${PROJECT_DIR}/working/${UNZIP_DIR}/boot/dts/$(basename "${dtb}" | sed 's/\.dtb/.dts/')"
@@ -157,6 +158,7 @@ if [[ -f "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_kernel_boot.img ]]; then
 
     # Extract 'dtb' and decompile then
     extract-dtb "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_kernel_boot.img -o "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_kernel_boot/dtb > /dev/null
+    rm -rf "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_kernel_boot/dtb/00_kernel
     if [ $(ls "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_kernel_boot/dtb) ]; then
         for dtb in $(find "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_kernel_boot/dtb); do
             dtc -q -I dtb -O dts "${dtb}" >> "${PROJECT_DIR}/working/${UNZIP_DIR}/vendor_kernel_boot/dts/$(basename "${dtb}" | sed 's/\.dtb/.dts/')"
@@ -182,6 +184,7 @@ if [[ -f "$PROJECT_DIR"/working/"${UNZIP_DIR}"/dtbo.img ]]; then
 
     # Extract 'dtb' and decompile them
     extract-dtb "$PROJECT_DIR"/working/"${UNZIP_DIR}"/dtbo.img -o "$PROJECT_DIR"/working/"${UNZIP_DIR}"/dtbo > /dev/null
+    rm -rf "$PROJECT_DIR"/working/"${UNZIP_DIR}"/dtbo/00_kernel
     for dtb in $(find "$PROJECT_DIR"/working/"${UNZIP_DIR}"/dtbo); do
         dtc -q -I dtb -O dts "${dtb}" >> "${PROJECT_DIR}/working/${UNZIP_DIR}/dtbo/dts/$(basename "${dtb}" | sed 's/\.dtb/.dts/')"
     done

--- a/dumpyara.sh
+++ b/dumpyara.sh
@@ -169,6 +169,13 @@ if [[ -f "$PROJECT_DIR"/working/"${UNZIP_DIR}"/vendor_kernel_boot.img ]]; then
     fi
 fi
 
+# Extract 'init_boot'
+if [[ -f "$PROJECT_DIR"/working/"${UNZIP_DIR}"/init_boot.img ]]; then
+    # Extract 'init_boot.img' content(s)
+    "${UNPACKBOOTIMG}" -i "$PROJECT_DIR"/working/"${UNZIP_DIR}"/init_boot.img -o "$PROJECT_DIR"/working/"${UNZIP_DIR}"/init_boot > /dev/null 2>&1
+    echo 'init_boot extracted'
+fi
+
 if [[ -f "$PROJECT_DIR"/working/"${UNZIP_DIR}"/dtbo.img ]]; then
     # Create necessary directories
     mkdir -p "$PROJECT_DIR"/working/"${UNZIP_DIR}"/dtbo/dts


### PR DESCRIPTION
This was tested on latest build for Pixel 7a, device containing said partitions. The script now generates different subfolder:
 * `vendor_boot/`, which contains output of unpackbootimg
     * `vendor_boot/dtb`, which contains output of `extract-dtb`
     * `vendor_boot/dts`, which contains output of `dtc`

### Major changes
 * Move over to `unpackbootimg` fork by osm0sis from `mkbootimg_tools` ([`f35165c`](https://github.com/AndroidDumps/dumpyara/pull/65/commits/f35165cdeccc1420182e51be76a18cff0c4e9a38), [`95fd829`](https://github.com/AndroidDumps/dumpyara/pull/65/commits/95fd829a3d403ddce83bbde4923c1d2f3c89db69))
 * Implement extracting of `vendor_boot.img` ([`c6ee171`](https://github.com/AndroidDumps/dumpyara/pull/65/commits/c6ee1715bf7320bcaf3e7609a270c47507cd34b0)), `vendor_kernel_boot.img` ([`996f705`](https://github.com/AndroidDumps/dumpyara/pull/65/commits/996f705bf4195a604bef9ab37d0811c5c7f30564)) and `init_boot.img` ([`94f1f89`](https://github.com/AndroidDumps/dumpyara/pull/65/commits/94f1f89195fdeae38e0a7385be9ea2bac87cf915))
 * Improve readability of the code ([`70f0b0a`](https://github.com/AndroidDumps/dumpyara/pull/65/commits/70f0b0a45ef5926d471fdea9304dea9248aee12a), [`21796f1`](https://github.com/AndroidDumps/dumpyara/pull/65/commits/21796f16665931aca93da5b163228ffeaefdb75c))