### PR TITLE
dumpyara: Rework file/URL input handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .tgtoken
 working/
 external/
+input/


### PR DESCRIPTION
Previously, the script entered the working/ directory and remained there, which was unintended and caused errors. Keep files on input/ and pass it to the rest of the progress.

---

Even though non-local file dumping may be deprecated, it's better to keep it working than leave it with a broken handler.