### PR TITLE
Improve on setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -59,6 +59,11 @@ if command -v apt > /dev/null 2>&1; then
     done
 # 'dnf' (Fedora)
 elif command -v dnf > /dev/null 2>&1; then
+# Perform repositories updates to prevent dead mirrors
+
+    LOGI "Updating repositories..."
+    $sudo_cmd dnf update -y --refresh > /dev/null 2>&1
+
     # Install required packages in form of a 'for' loop
     for package in unace unrar zip unzip sharutils uudeview arj cabextract file-roller dtc python3-pip brotli axel aria2 detox cpio lz4 python3-devel xz-devel p7zip p7zip-plugins ripgrep; do
         LOGI "Installing '${package}'..."
@@ -70,7 +75,7 @@ elif command -v pacman > /dev/null 2>&1; then
     # Install required packages in form of a 'for' loop
     for package in unace unrar zip unzip p7zip sharutils uudeview arj cabextract file-roller dtc python-pip brotli axel gawk aria2 detox cpio lz4 ripgrep; do
         LOGI "Installing '${package}'..."
-        $sudo_cmd pacman -Sy --noconfirm --needed "${package}" > /dev/null 2>&1 || \
+        $sudo_cmd pacman -Syu --noconfirm --needed "${package}" > /dev/null 2>&1 || \
             LOGE "Failed installing '${package}'."
     done
 #other

--- a/setup.sh
+++ b/setup.sh
@@ -40,12 +40,17 @@ fi
 if command -v apt > /dev/null 2>&1; then
     # Perform repositories updates to prevent dead mirrors
     LOGI "Updating repositories..."
-    $sudo_cmd apt update > /dev/null 2>&1
+    $sudo_cmd apt update && $sudo_cmd apt upgrade > /dev/null 2>&1
 
     # Install required packages in form of a 'for' loop
     for package in unace unrar zip unzip p7zip-full p7zip-rar sharutils rar uudeview mpack arj cabextract device-tree-compiler liblzma-dev python3-pip brotli liblz4-tool axel gawk aria2 detox cpio rename liblz4-dev curl ripgrep; do
         LOGI "Installing '${package}'..."
         $sudo_cmd apt install  -y "${package}" > /dev/null 2>&1 || \
+            if [ $package == "liblz4-tool" ]; then
+                LOGW "Failed to install liblx4-tool, trying lz4 instead"
+                $sudo_cmd apt install -y > /dev/null 2>&1 || \
+                    LOGE "Failed to install lz4"
+            fi
             LOGE "Failed installing '${package}'."
     done
 # 'dnf' (Fedora)
@@ -64,6 +69,9 @@ elif command -v pacman > /dev/null 2>&1; then
         $sudo_cmd pacman -Sy --noconfirm --needed "${package}" > /dev/null 2>&1 || \
             LOGE "Failed installing '${package}'."
     done
+#other
+else
+    LOGF "Your distro is unsupported. Please install the needed packages yourself."
 fi
 
 # Install 'uv' through pipx

--- a/setup.sh
+++ b/setup.sh
@@ -47,11 +47,11 @@ if command -v apt > /dev/null 2>&1; then
         LOGI "Installing '${package}'..."
         if ! $sudo_cmd apt install -y "${package}" > /dev/null 2>&1; then
             if [ $package == "liblz4-tool" ]; then
-                LOGW "Failed to install liblx4-tool, trying lz4 instead"
+                LOGW "Failed to install liblz4-tool, trying lz4 instead..."
                 if $sudo_cmd apt install -y lz4 > /dev/null 2>&1; then
                     continue
                 else
-                    LOGE "Failed to install lz4"
+                    LOGE "Failed to install lz4."
                 fi
             fi
             LOGE "Failed installing '${package}'."

--- a/setup.sh
+++ b/setup.sh
@@ -60,7 +60,6 @@ if command -v apt > /dev/null 2>&1; then
 # 'dnf' (Fedora)
 elif command -v dnf > /dev/null 2>&1; then
 # Perform repositories updates to prevent dead mirrors
-
     LOGI "Updating repositories..."
     $sudo_cmd dnf update -y --refresh > /dev/null 2>&1
 
@@ -72,10 +71,14 @@ elif command -v dnf > /dev/null 2>&1; then
     done
 # 'pacman' (Arch Linux)
 elif command -v pacman > /dev/null 2>&1; then
+# Perform repositories updates to prevent dead mirrors
+    LOGI "Updating repositories..."
+    $sudo_cmd pacman -Syu --noconfirm > /dev/null 2>&1
+
     # Install required packages in form of a 'for' loop
     for package in unace unrar zip unzip p7zip sharutils uudeview arj cabextract file-roller dtc python-pip brotli axel gawk aria2 detox cpio lz4 ripgrep; do
         LOGI "Installing '${package}'..."
-        $sudo_cmd pacman -Syu --noconfirm --needed "${package}" > /dev/null 2>&1 || \
+        $sudo_cmd pacman -S --noconfirm --needed "${package}" > /dev/null 2>&1 || \
             LOGE "Failed installing '${package}'."
     done
 #other

--- a/setup.sh
+++ b/setup.sh
@@ -40,18 +40,22 @@ fi
 if command -v apt > /dev/null 2>&1; then
     # Perform repositories updates to prevent dead mirrors
     LOGI "Updating repositories..."
-    $sudo_cmd apt update && $sudo_cmd apt upgrade > /dev/null 2>&1
+    $sudo_cmd apt update > /dev/null 2>&1 && $sudo_cmd apt upgrade -y > /dev/null 2>&1
 
     # Install required packages in form of a 'for' loop
     for package in unace unrar zip unzip p7zip-full p7zip-rar sharutils rar uudeview mpack arj cabextract device-tree-compiler liblzma-dev python3-pip brotli liblz4-tool axel gawk aria2 detox cpio rename liblz4-dev curl ripgrep; do
         LOGI "Installing '${package}'..."
-        $sudo_cmd apt install  -y "${package}" > /dev/null 2>&1 || \
+        if ! $sudo_cmd apt install -y "${package}" > /dev/null 2>&1; then
             if [ $package == "liblz4-tool" ]; then
                 LOGW "Failed to install liblx4-tool, trying lz4 instead"
-                $sudo_cmd apt install -y lz4 > /dev/null 2>&1 || \
+                if $sudo_cmd apt install -y lz4 > /dev/null 2>&1; then
+                    continue
+                else
                     LOGE "Failed to install lz4"
+                fi
             fi
             LOGE "Failed installing '${package}'."
+        fi
     done
 # 'dnf' (Fedora)
 elif command -v dnf > /dev/null 2>&1; then

--- a/setup.sh
+++ b/setup.sh
@@ -48,7 +48,7 @@ if command -v apt > /dev/null 2>&1; then
         $sudo_cmd apt install  -y "${package}" > /dev/null 2>&1 || \
             if [ $package == "liblz4-tool" ]; then
                 LOGW "Failed to install liblx4-tool, trying lz4 instead"
-                $sudo_cmd apt install -y > /dev/null 2>&1 || \
+                $sudo_cmd apt install -y lz4 > /dev/null 2>&1 || \
                     LOGE "Failed to install lz4"
             fi
             LOGE "Failed installing '${package}'."


### PR DESCRIPTION
This PR fixes the issue of _liblz4-tool_ not existing on newer versions, by trying lz4 instead in event of it's failure. Also add handling for unsupported OSes and upgrade all needed packages.