### PR TITLE
chore: set 'GIT_ORG' variable

### DIFF
--- a/dumpyara.sh
+++ b/dumpyara.sh
@@ -39,6 +39,15 @@ else
     LOGW "GitHub token not found. Dumping just locally..."
 fi
 
+# Github organization
+if [[ -n $3 ]]; then
+    GIT_ORG=$3
+elif [[ -f ".githuborganization" ]]; then
+    GIT_ORG=$(< .githuborganization)
+else
+    LOGW "GitHub organization not found. Dumping just locally..."
+fi
+
 # Check whether input is a string or a file
 if echo "${1}" | grep -e '^\(https\?\|ftp\)://.*$' > /dev/null; then
     # Set 'URL' to appended string
@@ -115,7 +124,11 @@ else
     fi
 fi
 
-ORG=AndroidDumps #your GitHub org name
+if [ -n "${GIT_ORG}" ]; then
+    ORG=$3 #your GitHub org name
+else
+    ORG=AndroidDumps #default Github org name
+fi
 EXTENSION=$(echo "${INPUT##*.}" | inline-detox)
 UNZIP_DIR=$(basename ${INPUT/.$EXTENSION/})
 WORKING=${PWD}/working/${UNZIP_DIR}


### PR DESCRIPTION
- This will allow us to directly pass our GitHub's organization name through an argument or a dotfile.
- This will help us to run the script in CI/CD smoothly for pushing dump repository.

Change-ID: 6ea5c920f2ab775699963910a2f77c7883281f91