### PR TITLE
chore: set 'GIT_ORG' variable

### DIFF
--- a/dumpyara.sh
+++ b/dumpyara.sh
@@ -227,7 +227,7 @@ for image in boot vendor_boot vendor_kernel_boot; do
 
         ## Retrive image's ramdisk, and extract it
         unlz4 "${image}"/"${image}".img-*ramdisk "${image}/ramdisk.lz4" >> /dev/null 2>&1
-        7z -snld x "${image}/ramdisk.lz4" -o"${image}/ramdisk" >> /dev/null 2>&1  || \
+        7zz -snld x "${image}/ramdisk.lz4" -o"${image}/ramdisk" >> /dev/null 2>&1  || \
             LOGI "Failed to extract ramdisk."
 
         ## Clean-up
@@ -479,7 +479,7 @@ description=$(rg -m1 -INoP --no-messages "(?<=^ro.build.description=).*" {system
 # Generate dummy device tree
 mkdir -p "${WORKING}/aosp-device-tree"
 LOGI "Generating dummy device tree..."
-uvx aospdtgen . --output "${WORKING}/aosp-device-tree" >> /dev/null 2>&1 || \
+uvx aospdtgen@1.1.1 . --output "${WORKING}/aosp-device-tree" >> /dev/null 2>&1 || \
     LOGE "Failed to generate AOSP device tree" && rm -rf "${WORKING}/aosp-device-tree"
 
 is_ab=$(grep -oP "(?<=^ro.build.ab_update=).*" -hs {system,system/system,vendor}/build*.prop | head -1)

--- a/dumpyara.sh
+++ b/dumpyara.sh
@@ -218,7 +218,7 @@ fi
 for image in boot vendor_boot vendor_kernel_boot; do
     if [[ -f "${image}".img ]]; then
         # Create working directories
-        mkdir -p "${image}/dtb" "${image}/dts"
+        mkdir -p "${image}/ramdisk" "${image}/dtb" "${image}/dts"
 
         # Unpack image's content
         LOGI "Extracting '${image}' content..."

--- a/dumpyara.sh
+++ b/dumpyara.sh
@@ -39,6 +39,15 @@ else
     LOGW "GitHub token not found. Dumping just locally..."
 fi
 
+# GitHub organization
+if [[ -n $3 ]]; then
+    GIT_ORG=$3
+elif [[ -f ".githuborganization" ]]; then
+    GIT_ORG=$(< .githuborganization)
+else
+    LOGW "GitHub organization not found. Dumping just locally..."
+fi
+
 # Check whether input is a string or a file
 if echo "${1}" | grep -e '^\(https\?\|ftp\)://.*$' > /dev/null; then
     # Set 'URL' to appended string
@@ -115,7 +124,11 @@ else
     fi
 fi
 
-ORG=AndroidDumps #your GitHub org name
+if [ -n "${GIT_ORG}" ]; then
+    ORG=$3 #your GitHub org name
+else
+    ORG=AndroidDumps #default GitHub org name
+fi
 EXTENSION=$(echo "${INPUT##*.}" | inline-detox)
 UNZIP_DIR=$(basename ${INPUT/.$EXTENSION/})
 WORKING=${PWD}/working/${UNZIP_DIR}

--- a/dumpyara.sh
+++ b/dumpyara.sh
@@ -125,7 +125,7 @@ else
 fi
 
 if [ -n "${GIT_ORG}" ]; then
-    ORG=$3 #your GitHub org name
+    ORG=${GIT_ORG} #your GitHub org name
 else
     ORG=AndroidDumps #default GitHub org name
 fi

--- a/dumpyara.sh
+++ b/dumpyara.sh
@@ -218,15 +218,16 @@ fi
 for image in boot vendor_boot vendor_kernel_boot; do
     if [[ -f "${image}".img ]]; then
         # Create working directories
+        mkdir "${image}"
         mkdir -p "${image}/ramdisk" "${image}/dtb" "${image}/dts"
 
         # Unpack image's content
         LOGI "Extracting '${image}' content..."
-        ${UNPACKBOOTIMG} -i "${image}.img" -o "${image}/" > /dev/null || \
+        ${UNPACKBOOTIMG} -i "${image}.img" -o "${PWD}/${image}" > /dev/null || \
             LOGE "Extraction via 'unpackbootimg' unsuccessful."
 
         ## Retrive image's ramdisk, and extract it
-        unlz4 "${image}"/"${image}".img-*ramdisk "${image}/ramdisk.lz4" >> /dev/null 2>&1
+        unlz4 "${image}/${image}".img-*ramdisk "${image}/ramdisk.lz4" >> /dev/null 2>&1
         7zz -snld x "${image}/ramdisk.lz4" -o"${image}/ramdisk" >> /dev/null 2>&1  || \
             LOGI "Failed to extract ramdisk."
 


### PR DESCRIPTION
- This will allow us to directly pass our GitHub organization through an argument or a dotfile.
- This will help us to run the script in CI/CD smoothly for pushing dump repository.

Change-Id: I4ff1350fe03f04e4b9ea8a7c88eabeb961b2f1d9