### PR TITLE
Add support for f2fs partitions (such as with Samsung devices)

### DIFF
--- a/dumpyara.sh
+++ b/dumpyara.sh
@@ -169,23 +169,33 @@ PARTITIONS=(system systemex system_ext system_other vendor cust odm odm_ext oem 
 # Extract the images
 LOGI "Extracting partitions..."
 for partition in "${PARTITIONS[@]}"; do
-    # Proceed only if the image from 'PARTITIONS' array exists
-    if [[ -f "${partition}".img ]]; then
+    if [[ -f "${partition}.img" ]]; then
+        LOGI "Processing '${partition}.img'..."
         # Try to extract file through '7z'
-        ${FSCK_EROFS} --extract="${partition}" "${partition}".img >> /dev/null 2>&1 || {
-                # Try to extract file through '7z'
-                7z -snld x "${partition}".img -y -o"${partition}"/ > /dev/null || {
-                LOGE "'${partition}' extraction via '7z' failed."
+        if ! ${FSCK_EROFS} --extract="${partition}" "${partition}.img" >/dev/null 2>&1; then
+            # Try to extract file through '7z'
+            if ! 7z -snld x "${partition}.img" -y -o"${partition}/" >/dev/null 2>&1; then
+                LOGW "'${partition}' extraction via 7z failed, trying F2FS..."
 
-                # Only abort if we're at the first occourence
-                if [[ "${partition}" == "${PARTITIONS[0]}" ]]; then
-                    LOGF "Aborting dumping considering it's a crucial partition."
+                sudo mkdir -p "/mnt/${partition}" "./${partition}"
+
+                if sudo mount -t f2fs -o loop,ro "${partition}.img" "/mnt/${partition}" >/dev/null 2>&1; then
+                    sudo cp -a "/mnt/${partition}/." "./${partition}/" >/dev/null 2>&1 && LOGI "Copied '${partition}' successfully."
+                    sudo chown -R "$(id -u):$(id -g)" "./${partition}"
+                    sudo umount "/mnt/${partition}" >/dev/null 2>&1
+                    sudo rm -rf "/mnt/${partition}"
+                else
+                    LOGE "'${partition}' extraction via F2FS mount failed."
+                    if [[ "${partition}" == "${PARTITIONS[0]}" ]]; then
+                        LOGF "Aborting dumping considering it's a crucial partition."
+                    fi
+                    continue
                 fi
-            }
-        }
+            fi
+        fi
 
-        # Clean-up
-        rm -f "${partition}".img
+        # Clean up
+        rm -f "${partition}.img"
     fi
 done
 


### PR DESCRIPTION
Previously, since 7z doesn't support f2fs _.img_ files, on devices using f2fs for logical partition the script would fail. It now works (at least on my test image, One UI 7 for the Galaxy A33 5G).